### PR TITLE
Scroll to Top functionality

### DIFF
--- a/blog-dont-lie/src/App.js
+++ b/blog-dont-lie/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Header from "./components/Header";
 // import Navbar from "./components/Navbar";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
+import ScrollToTop from "./components/ScrollToTop";
 import Homepage from "./components/Homepage";
 import All_influential_team from "./components/posts/1-all-influential-team/1-all-influential-team";
 import Lowry_iguodala from "./components/posts/2-lowry-iguodala/2-lowry-iguodala";
@@ -12,6 +13,7 @@ class App extends React.Component {
     return (
       <div className="App">
         <BrowserRouter>
+          <ScrollToTop />
           <Header />
           {/* <Navbar /> */}
           <Switch>

--- a/blog-dont-lie/src/components/ScrollToTop.js
+++ b/blog-dont-lie/src/components/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
**What's Going On?**
I added the ScrollToTop function (h/t to [React Router docs](https://reacttraining.com/react-router/web/guides/scroll-restoration)) that enables scroll-to-top on navigation.
Before this fix, if user clicked a link while scrolled down, they'd be redirected but the page wouldn't scroll up. This meant they could be redirected to the middle of an article.

This fix solves that problem.